### PR TITLE
[/mydashboard, 사이드메뉴] 사이드메뉴, /mydashboard 기능 구현

### DIFF
--- a/components/button/Button.style.ts
+++ b/components/button/Button.style.ts
@@ -277,7 +277,8 @@ export const BUTTON_COMPONENTS = {
     align-items: center;
     justify-content: space-between;
     padding: 2.6rem 2rem;
-    width: ${({ $width }) => $width};
+    /* width: ${({ $width }) => $width}; */
+    min-width: 100%;
     height: ${({ $height }) => $height};
     border-radius: 0.8rem;
     border: 0.1rem solid var(--gray_060);
@@ -292,16 +293,15 @@ export const BUTTON_COMPONENTS = {
     > div {
       display: flex;
       align-items: center;
-      gap: 1.6rem;
     }
 
     @media ${device.tablet} {
-      width: 24.7rem;
+      width: 100%;
       height: 6.8rem;
     }
 
     @media ${device.mobile} {
-      width: 26rem;
+      width: 100%;
       height: 5.8rem;
       font-size: 1.4rem;
     }

--- a/components/side-menu/Menu.style.ts
+++ b/components/side-menu/Menu.style.ts
@@ -1,8 +1,13 @@
 import { device } from '@/styles/breakpoints';
 import Image from 'next/image';
+import Link from 'next/link';
 import styled from 'styled-components';
 
-export const Menu = styled.section`
+interface MenuItemType {
+  displayStyle: string;
+}
+
+export const Menu = styled.div`
   gap: 0.6rem;
   font-size: 1.8rem;
   font-weight: 500;
@@ -46,11 +51,12 @@ export const MenuItemContainerStyle = styled.div`
   }
 `;
 
-export const MenuItem = styled.span`
+export const MenuItem = styled.span<MenuItemType>`
   color: var(--gray_000);
 
   @media ${device.mobile} {
-    display: none;
+    display: ${({ displayStyle }) => displayStyle};
+    margin-left: 1.2rem;
   }
   @media ${device.mobileMin} {
     width: 100%;

--- a/components/side-menu/Menu.tsx
+++ b/components/side-menu/Menu.tsx
@@ -4,25 +4,26 @@ import { MenuType } from './type';
 
 interface Props {
   dashboard: Dashboard;
-  index: number;
   selectedDashboardIndex: number;
   setSelectedDashboardIndex: React.Dispatch<React.SetStateAction<number>>;
+  type: string;
+  id: number;
 }
 
-const Menu = ({ dashboard, index, selectedDashboardIndex, setSelectedDashboardIndex }: Props) => {
+const Menu = ({ dashboard, selectedDashboardIndex, setSelectedDashboardIndex, type, id }: Props) => {
   const handleOnDashboardSelect = () => {
-    setSelectedDashboardIndex(index);
-    console.log(index);
+    if (type === 'sideMenu') {
+      setSelectedDashboardIndex(id);
+    }
   };
 
   return (
-    <S.Menu onClick={handleOnDashboardSelect} color={selectedDashboardIndex === index ? 'var(--violet_100)' : 'none'}>
+    <S.Menu onClick={handleOnDashboardSelect} color={selectedDashboardIndex === id && type === 'sideMenu' ? 'var(--violet_100)' : 'none'}>
       <S.MenuContainer>
         <S.Point color={dashboard.color} />
         <S.MenuItemContainerStyle>
-          {/* 내가 만든 대시보드에만 달리게 조건 달아줘야 함 */}
           {dashboard.createdByMe && <S.CrownIcon src='/icons/Crown.svg' alt='왕관 아이콘' width={18} height={14} />}
-          <S.MenuItem>{dashboard.title}</S.MenuItem>
+          <S.MenuItem displayStyle={type === 'sideMenu' ? 'none' : 'block'}>{dashboard.title}</S.MenuItem>
         </S.MenuItemContainerStyle>
       </S.MenuContainer>
     </S.Menu>

--- a/components/side-menu/SideMenu.tsx
+++ b/components/side-menu/SideMenu.tsx
@@ -6,6 +6,7 @@ import ModalNewdash from '../Modal/ModalNewdash';
 import { useResource } from '@/hooks/useResource';
 import { BaseDashboard, Dashboard } from '@/hooks/useDashboards';
 import useGetDashboards from '@/query/useGetDashboards';
+import Link from 'next/link';
 
 const COLOR = ['--green_100', '--purple_100', '--orange_100', '--blue_100', '--pink_100', '--green_100'];
 const MENU_NAME = ['비브리지', '코드잇', '3분기 계획', '회의록', '중요 문서함', '가나다라마바아'];
@@ -56,27 +57,31 @@ const SideMenu = () => {
         <Add $width='2rem' $height='2rem' onClick={handleOpenModal} />
       </S.Container>
       <S.ListContainer>
-        {myDashboards.map((dashboard, index) => (
-          <Menu
-            key={dashboard.id}
-            index={index}
-            dashboard={dashboard}
-            selectedDashboardIndex={selectedDashboardIndex}
-            setSelectedDashboardIndex={(index) => {
-              setSelectedDashboardIndex(index);
-            }}
-          />
+        {myDashboards.map((dashboard) => (
+          <Link href={`/dashboard/${dashboard.id}`} key={dashboard.id}>
+            <Menu
+              id={dashboard.id}
+              dashboard={dashboard}
+              selectedDashboardIndex={selectedDashboardIndex}
+              setSelectedDashboardIndex={(index) => {
+                setSelectedDashboardIndex(index);
+              }}
+              type='sideMenu'
+            />
+          </Link>
         ))}
-        {inviteDashBoards.map((dashboard, index) => (
-          <Menu
-            key={dashboard.id}
-            index={index}
-            dashboard={dashboard}
-            selectedDashboardIndex={selectedDashboardIndex}
-            setSelectedDashboardIndex={(index) => {
-              setSelectedDashboardIndex(index);
-            }}
-          />
+        {inviteDashBoards.map((dashboard) => (
+          <Link href={`/dashboard/${dashboard.id}`} key={dashboard.id}>
+            <Menu
+              id={dashboard.id}
+              dashboard={dashboard}
+              selectedDashboardIndex={selectedDashboardIndex}
+              setSelectedDashboardIndex={(index) => {
+                setSelectedDashboardIndex(index);
+              }}
+              type='sideMenu'
+            />
+          </Link>
         ))}
       </S.ListContainer>
       {isModalOpen && <ModalNewdash dashboards={dashboards} onClose={handleCloseModal} />}

--- a/components/table/invitedash/InviteDash.style.ts
+++ b/components/table/invitedash/InviteDash.style.ts
@@ -110,6 +110,9 @@ export const ArrowNextPage = styled(Image)`
 
 export const InviteDashListStyle = styled.article`
   width: 100%;
+  height: 60rem;
+  overflow: scroll;
+  overflow-x: hidden;
   background-color: var(--white_100);
 
   @media ${device.tablet} {

--- a/components/table/invitedash/InviteDash.tsx
+++ b/components/table/invitedash/InviteDash.tsx
@@ -11,6 +11,7 @@ import useGetDashboards from '@/query/useGetDashboards';
 import { apiCall } from '@/pages/api/api';
 import Noinvited from '../no-invited-dashboard/NoInvited';
 import Link from 'next/link';
+import { BaseDashboard } from '@/hooks/useDashboards';
 
 const INVITE_ITEM = [
   ['프로덕트 디자인', '손동희'],
@@ -20,11 +21,33 @@ const INVITE_ITEM = [
   ['유닛 C', '김태현'],
   ['유닛 D', '정혜진'],
 ];
+export interface ResInviteData {
+  cursorId: number;
+  invitations: InviteData[];
+}
+
+export interface InviteData {
+  id: number;
+  inviter: Invite;
+  teamId: string;
+  dashboard: BaseDashboard;
+  invitee: Invite;
+  inviteAccepted: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface Invite {
+  nickname: string;
+  email: string;
+  id: number;
+}
 
 const InviteDash = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedDashboardIndex, setSelectedDashboardIndex] = useState(-1);
-  const [inviteData, setInviteData] = useState();
+  const [inviteData, setInviteData] = useState<ResInviteData>();
+  const [searchInput, setSearchInput] = useState('');
 
   const handleOpenModal = () => setIsModalOpen(true);
   const handleCloseModal = () => setIsModalOpen(false);
@@ -33,7 +56,7 @@ const InviteDash = () => {
 
   useEffect(() => {
     const fetch = async () => {
-      const data = await apiCall('get', 'https://sp-taskify-api.vercel.app/4-8/invitations?size=10');
+      const data: ResInviteData = await apiCall('get', 'https://sp-taskify-api.vercel.app/4-8/invitations?size=10');
       setInviteData(data);
     };
     fetch();
@@ -46,6 +69,11 @@ const InviteDash = () => {
 
   const myDashboards = dashboards.filter((dashboard) => dashboard.createdByMe);
   const inviteDashBoards = dashboards.filter((dashboard) => !dashboard.createdByMe);
+
+  // 검색 결과 필터링
+  const filteredInvitations = inviteData?.invitations.filter((item) =>
+    item.dashboard.title.toLowerCase().includes(searchInput.toLowerCase())
+  );
 
   return (
     <S.InviteDashStyle>
@@ -107,7 +135,7 @@ const InviteDash = () => {
           <S.InviteDashContainerStyle>
             <S.TitleStyle>초대받은 대시보드</S.TitleStyle>
             <S.SearchFormStyle>
-              <S.SearchInputStyle placeholder='검색' />
+              <S.SearchInputStyle placeholder='검색' value={searchInput} onChange={(e) => setSearchInput(e.target.value)} />
               <Search />
             </S.SearchFormStyle>
           </S.InviteDashContainerStyle>
@@ -117,7 +145,7 @@ const InviteDash = () => {
             <S.ListHeaderItemStyle>수락 여부</S.ListHeaderItemStyle>
           </S.ListHeaderStyle>
           <S.ListStyle>
-            {inviteData?.invitations.map((item) => (
+            {filteredInvitations?.map((item) => (
               <InviteItem
                 key={item.id}
                 id={item.id}
@@ -128,7 +156,7 @@ const InviteDash = () => {
             ))}
           </S.ListStyle>
           <S.ListMobileStyle>
-            {inviteData?.invitations.map((item) => (
+            {filteredInvitations?.map((item) => (
               <InviteItemMobile
                 key={item.id}
                 id={item.id}

--- a/components/table/invitedash/InviteDash.tsx
+++ b/components/table/invitedash/InviteDash.tsx
@@ -1,14 +1,16 @@
-import { Arrow_forward, Arrow_forward_disabled, Search } from '@/components/Icons';
+import { Arrow_forward, Search } from '@/components/Icons';
 import * as S from './InviteDash.style';
 import InviteItem from './InviteItem';
 import InviteItemMobile from './InviteItemMobile';
 import Button from '@/components/button/Button';
 import PlusChip from '@/components/chips/plus-chip/PlusChip';
-import useDashboards from '@/hooks/useDashboards';
 import { useEffect, useState } from 'react';
 import Menu from '@/components/side-menu/Menu';
 import ModalNewdash from '@/components/Modal/ModalNewdash';
 import useGetDashboards from '@/query/useGetDashboards';
+import { apiCall } from '@/pages/api/api';
+import Noinvited from '../no-invited-dashboard/NoInvited';
+import Link from 'next/link';
 
 const INVITE_ITEM = [
   ['프로덕트 디자인', '손동희'],
@@ -21,11 +23,21 @@ const INVITE_ITEM = [
 
 const InviteDash = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedDashboardIndex, setSelectedDashboardIndex] = useState(-1);
+  const [inviteData, setInviteData] = useState();
 
   const handleOpenModal = () => setIsModalOpen(true);
   const handleCloseModal = () => setIsModalOpen(false);
 
   const { data, isPending, isError } = useGetDashboards();
+
+  useEffect(() => {
+    const fetch = async () => {
+      const data = await apiCall('get', 'https://sp-taskify-api.vercel.app/4-8/invitations?size=10');
+      setInviteData(data);
+    };
+    fetch();
+  }, []);
 
   if (isPending) return <div>로딩중</div>;
   if (isError) return <div>에러</div>;
@@ -43,16 +55,42 @@ const InviteDash = () => {
           <PlusChip />
         </Button>
         {myDashboards.map((dashboard) => (
-          <Button variant='dashboard' $width='33.2rem' $height='7rem'>
-            <div>
-              <S.ButtonColorPointStyle color={dashboard.color} />
-              <Menu key={dashboard.id} dashboard={dashboard} />
-            </div>
-            <Arrow_forward $width='1.8rem' $height='1.8rem' />
-          </Button>
+          <Link href={`/dashboard/${dashboard.id}`} key={dashboard.id}>
+            <Button variant='dashboard' $width='33.2rem' $height='7rem'>
+              <div>
+                <S.ButtonColorPointStyle color={dashboard.color} />
+                <Menu
+                  id={dashboard.id}
+                  dashboard={dashboard}
+                  selectedDashboardIndex={selectedDashboardIndex}
+                  setSelectedDashboardIndex={(index) => {
+                    setSelectedDashboardIndex(index);
+                  }}
+                  type='button'
+                />
+              </div>
+              <Arrow_forward $width='1.8rem' $height='1.8rem' />
+            </Button>
+          </Link>
         ))}
         {inviteDashBoards.map((dashboard) => (
-          <Menu key={dashboard.id} dashboard={dashboard} />
+          <Link href={`/dashboard/${dashboard.id}`} key={dashboard.id}>
+            <Button variant='dashboard' $width='33.2rem' $height='7rem'>
+              <div>
+                <S.ButtonColorPointStyle color={dashboard.color} />
+                <Menu
+                  id={dashboard.id}
+                  dashboard={dashboard}
+                  selectedDashboardIndex={selectedDashboardIndex}
+                  setSelectedDashboardIndex={(index) => {
+                    setSelectedDashboardIndex(index);
+                  }}
+                  type='button'
+                />
+              </div>
+              <Arrow_forward $width='1.8rem' $height='1.8rem' />
+            </Button>
+          </Link>
         ))}
       </S.ButtonContainerStyle>
       <S.PageNationContainer>
@@ -62,30 +100,46 @@ const InviteDash = () => {
           <S.ArrowNextPage src='/icons/Arrow_forward.svg' alt='다음 페이지로' width={40} height={40} />
         </S.ArrowContainer>
       </S.PageNationContainer>
-      <S.InviteDashListStyle>
-        <S.InviteDashContainerStyle>
-          <S.TitleStyle>초대받은 대시보드</S.TitleStyle>
-          <S.SearchFormStyle>
-            <S.SearchInputStyle placeholder='검색' />
-            <Search />
-          </S.SearchFormStyle>
-        </S.InviteDashContainerStyle>
-        <S.ListHeaderStyle>
-          <S.ListHeaderItemStyle>이름</S.ListHeaderItemStyle>
-          <S.ListHeaderItemStyle>초대자</S.ListHeaderItemStyle>
-          <S.ListHeaderItemStyle>수락 여부</S.ListHeaderItemStyle>
-        </S.ListHeaderStyle>
-        <S.ListStyle>
-          {INVITE_ITEM.map((item, i) => (
-            <InviteItem key={i} name={item[0]} inviter={item[1]} />
-          ))}
-        </S.ListStyle>
-        <S.ListMobileStyle>
-          {INVITE_ITEM.map((item, i) => (
-            <InviteItemMobile key={i} name={item[0]} inviter={item[1]} />
-          ))}
-        </S.ListMobileStyle>
-      </S.InviteDashListStyle>
+      {inviteData?.invitations.length === 0 ? (
+        <Noinvited />
+      ) : (
+        <S.InviteDashListStyle>
+          <S.InviteDashContainerStyle>
+            <S.TitleStyle>초대받은 대시보드</S.TitleStyle>
+            <S.SearchFormStyle>
+              <S.SearchInputStyle placeholder='검색' />
+              <Search />
+            </S.SearchFormStyle>
+          </S.InviteDashContainerStyle>
+          <S.ListHeaderStyle>
+            <S.ListHeaderItemStyle>이름</S.ListHeaderItemStyle>
+            <S.ListHeaderItemStyle>초대자</S.ListHeaderItemStyle>
+            <S.ListHeaderItemStyle>수락 여부</S.ListHeaderItemStyle>
+          </S.ListHeaderStyle>
+          <S.ListStyle>
+            {inviteData?.invitations.map((item) => (
+              <InviteItem
+                key={item.id}
+                id={item.id}
+                name={item.dashboard.title}
+                inviter={item.inviter.nickname}
+                setInviteData={setInviteData}
+              />
+            ))}
+          </S.ListStyle>
+          <S.ListMobileStyle>
+            {inviteData?.invitations.map((item) => (
+              <InviteItemMobile
+                key={item.id}
+                id={item.id}
+                name={item.dashboard.title}
+                inviter={item.inviter.nickname}
+                setInviteData={setInviteData}
+              />
+            ))}
+          </S.ListMobileStyle>
+        </S.InviteDashListStyle>
+      )}
       {isModalOpen && <ModalNewdash dashboards={dashboards} onClose={handleCloseModal} />}
     </S.InviteDashStyle>
   );

--- a/components/table/invitedash/InviteItem.tsx
+++ b/components/table/invitedash/InviteItem.tsx
@@ -1,17 +1,30 @@
 import Button from '@/components/button/Button';
 import { InviteItemType } from '../type';
 import * as S from './InviteItem.style';
+import { apiCall } from '@/pages/api/api';
 
-const InviteItem = ({ name, inviter }: InviteItemType) => {
+const InviteItem = ({ name, inviter, id, setInviteData }: InviteItemType) => {
+  const handleClick = async (isAccepted: boolean) => {
+    try {
+      await apiCall('put', `https://sp-taskify-api.vercel.app/4-8/invitations/${id}`, {
+        inviteAccepted: isAccepted,
+      });
+      const data = await apiCall('get', 'https://sp-taskify-api.vercel.app/4-8/invitations?size=10');
+      setInviteData(data);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
   return (
     <S.InviteItemStyle>
       <S.ItemStyle>{name}</S.ItemStyle>
       <S.ItemStyle>{inviter}</S.ItemStyle>
       <S.ButtonContainerStyle>
-        <Button variant='accept' $width='8.4rem' $height='3.2rem'>
+        <Button variant='accept' $width='8.4rem' $height='3.2rem' onClick={() => handleClick(true)}>
           수락
         </Button>
-        <Button variant='reject' $width='8.4rem' $height='3.2rem'>
+        <Button variant='reject' $width='8.4rem' $height='3.2rem' onClick={() => handleClick(false)}>
           거절
         </Button>
       </S.ButtonContainerStyle>

--- a/components/table/invitedash/InviteItem.tsx
+++ b/components/table/invitedash/InviteItem.tsx
@@ -6,7 +6,7 @@ import { apiCall } from '@/pages/api/api';
 const InviteItem = ({ name, inviter, id, setInviteData }: InviteItemType) => {
   const handleClick = async (isAccepted: boolean) => {
     try {
-      await apiCall('put', `https://sp-taskify-api.vercel.app/4-8/invitations/${id}`, {
+      await apiCall('put', `https://sp-taskify-api.vercel.app/4-8/invitations/${dashboardid}`, {
         inviteAccepted: isAccepted,
       });
       const data = await apiCall('get', 'https://sp-taskify-api.vercel.app/4-8/invitations?size=10');

--- a/components/table/invitedash/InviteItemMobile.tsx
+++ b/components/table/invitedash/InviteItemMobile.tsx
@@ -1,8 +1,21 @@
 import Button from '@/components/button/Button';
 import { InviteItemType } from '../type';
 import * as S from './InviteItemMobile.style';
+import { apiCall } from '@/pages/api/api';
 
-const InviteItemMobile = ({ name, inviter }: InviteItemType) => {
+const InviteItemMobile = ({ name, inviter, id, setInviteData }: InviteItemType) => {
+  const handleClick = async (isAccepted: boolean) => {
+    try {
+      await apiCall('put', `https://sp-taskify-api.vercel.app/4-8/invitations/${id}`, {
+        inviteAccepted: isAccepted,
+      });
+      const data = await apiCall('get', 'https://sp-taskify-api.vercel.app/4-8/invitations?size=10');
+      setInviteData(data);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
   return (
     <S.InviteItemMobileStyle>
       <S.NameLabelStyle>
@@ -16,10 +29,10 @@ const InviteItemMobile = ({ name, inviter }: InviteItemType) => {
         </S.ContainerStyle>
       </S.NameLabelStyle>
       <S.ButtonContainerStyle>
-        <Button variant='accept' $width='50%' $height='50%'>
+        <Button variant='accept' $width='50%' $height='50%' onClick={() => handleClick(true)}>
           수락
         </Button>
-        <Button variant='reject' $width='50%' $height='50%'>
+        <Button variant='reject' $width='50%' $height='50%' onClick={() => handleClick(true)}>
           거절
         </Button>
       </S.ButtonContainerStyle>

--- a/components/table/invitedash/InviteItemMobile.tsx
+++ b/components/table/invitedash/InviteItemMobile.tsx
@@ -6,7 +6,7 @@ import { apiCall } from '@/pages/api/api';
 const InviteItemMobile = ({ name, inviter, id, setInviteData }: InviteItemType) => {
   const handleClick = async (isAccepted: boolean) => {
     try {
-      await apiCall('put', `https://sp-taskify-api.vercel.app/4-8/invitations/${id}`, {
+      await apiCall('put', `https://sp-taskify-api.vercel.app/4-8/invitations/${dashboardid}`, {
         inviteAccepted: isAccepted,
       });
       const data = await apiCall('get', 'https://sp-taskify-api.vercel.app/4-8/invitations?size=10');

--- a/components/table/no-invited-dashboard/NoInvited.tsx
+++ b/components/table/no-invited-dashboard/NoInvited.tsx
@@ -1,0 +1,16 @@
+import { Unsubscribe } from '@/components/Icons';
+import * as S from './NoInvitedDashboard.style';
+
+const Noinvited = () => {
+  return (
+    <S.UnsubscribeWrapper>
+      <S.UnsubscribeTitle>초대받은 대시보드</S.UnsubscribeTitle>
+      <S.UnsubscribeContainer>
+        <Unsubscribe $width='10rem' $height='10rem' />
+        <S.UnsubscribeText>아직 초대받은 대시보드가 없어요</S.UnsubscribeText>
+      </S.UnsubscribeContainer>
+    </S.UnsubscribeWrapper>
+  );
+};
+
+export default Noinvited;

--- a/components/table/type.ts
+++ b/components/table/type.ts
@@ -1,6 +1,10 @@
+import { SetStateAction } from 'react';
+
 export interface InviteItemType {
   name: string;
   inviter: string;
+  id: number;
+  setInviteData: React.Dispatch<SetStateAction<any>>;
 }
 
 export interface TableType {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "taskify-4th-8team",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.32.0",
+        "@tanstack/react-query-devtools": "^5.32.0",
         "axios": "^1.6.8",
         "next": "14.2.1",
         "next-images": "^1.8.5",
@@ -2751,6 +2753,55 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.32.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.32.0.tgz",
+      "integrity": "sha512-Z3flEgCat55DRXU5UMwYU1U+DgFZKA3iufyOKs+II7iRAo0uXkeU7PH5e6sOH1CGEag0IpKmZxlUFpCg6roSKw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.28.10",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.28.10.tgz",
+      "integrity": "sha512-5UN629fKa5/1K/2Pd26gaU7epxRrYiT1gy+V+pW5K6hnf1DeUKK3pANSb2eHKlecjIKIhTwyF7k9XdyE2gREvQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.32.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.32.0.tgz",
+      "integrity": "sha512-+E3UudQtarnx9A6xhpgMZapyF+aJfNBGFMgI459FnduEZqT/9KhOWnMOneZahLRt52yzskSA0AuOyLkXHK0yBA==",
+      "dependencies": {
+        "@tanstack/query-core": "5.32.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.32.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.32.0.tgz",
+      "integrity": "sha512-KWrzLoUjs9JtDSH3H2qbm5MjjykyAT8DkvP8tukw3gBG4ziu5WaWHciBjMsYSe1JB79AOxxGovzjW/Cd9+ofVw==",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.28.10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.32.0",
+        "react": "^18.0.0"
+      }
+    },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
@@ -2879,6 +2930,11 @@
         "@types/lodash": "*"
       }
     },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
+    },
     "node_modules/@types/node": {
       "version": "20.12.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
@@ -2900,6 +2956,16 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
       "devOptional": true
+    },
+    "node_modules/@types/qs": {
+      "version": "6.9.15",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
+      "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg=="
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
     },
     "node_modules/@types/react": {
       "version": "18.2.78",
@@ -3271,6 +3337,18 @@
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "peer": true
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/acorn": {
       "version": "8.11.3",
@@ -4499,6 +4577,14 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -5667,6 +5753,22 @@
         "node": ">= 6"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -6091,6 +6193,11 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/http-parser-js": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
+      "integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q=="
     },
     "node_modules/http-proxy": {
       "version": "1.18.1",
@@ -7034,6 +7141,17 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -7052,6 +7170,19 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -7121,6 +7252,14 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -7698,6 +7837,26 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-addr/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/proxy-from-env": {
@@ -9336,6 +9495,19 @@
         }
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/uuid": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -9346,6 +9518,14 @@
       ],
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/warning": {
@@ -9367,6 +9547,14 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/wbuf": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
+      "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
+      "dependencies": {
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "node_modules/webpack": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   },
   "type": "module",
   "dependencies": {
+    "@tanstack/react-query": "^5.32.0",
+    "@tanstack/react-query-devtools": "^5.32.0",
     "axios": "^1.6.8",
     "next": "14.2.1",
     "next-images": "^1.8.5",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,13 +1,14 @@
 import type { AppProps } from 'next/app';
 import GlobalStyle from '../styles/GlobalStyle';
 import FontStyle from '../styles/FontStyle';
+import Provider from '@/QueryClientProvier';
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <>
+    <Provider>
       <GlobalStyle />
       <FontStyle />
       <Component {...pageProps} />
-    </>
+    </Provider>
   );
 }

--- a/pages/api/axios.ts
+++ b/pages/api/axios.ts
@@ -1,5 +1,8 @@
 import axios from 'axios';
 
+const token =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MzEyNSwidGVhbUlkIjoiNC04IiwiaWF0IjoxNzE0MDM2MDMxLCJpc3MiOiJzcC10YXNraWZ5In0.U-iHdD_4bfOXm_n3T_d1oK7WhRpX9axIk2ynRIdEylA';
+
 const api = axios.create({
   baseURL: 'https://sp-taskify-api.vercel.app/4-8',
   headers: {

--- a/pages/mydashboard.tsx
+++ b/pages/mydashboard.tsx
@@ -1,9 +1,7 @@
 import SideMenu from '@/components/side-menu/SideMenu';
 import * as S from './mydashboard.style';
-import NoInvitedDashboard from '@/components/table/no-invited-dashboard/NoInvitedDashboard';
 import InviteDash from '@/components/table/invitedash/InviteDash';
 import DashboardHeader from '@/components/DashboardHeader/DashboardHeader';
-import Noinvited from '@/components/table/no-invited-dashboard/NoInvited';
 
 const MyDashBoard = () => {
   return (
@@ -12,7 +10,6 @@ const MyDashBoard = () => {
       <S.MyDashBoardWrapperStyle>
         <S.ContainerStyle>
           <DashboardHeader isVisible='false'>내 대시보드</DashboardHeader>
-          {/* <NoInvitedDashboard /> */}
           <InviteDash />
         </S.ContainerStyle>
       </S.MyDashBoardWrapperStyle>

--- a/pages/mydashboard.tsx
+++ b/pages/mydashboard.tsx
@@ -3,6 +3,7 @@ import * as S from './mydashboard.style';
 import NoInvitedDashboard from '@/components/table/no-invited-dashboard/NoInvitedDashboard';
 import InviteDash from '@/components/table/invitedash/InviteDash';
 import DashboardHeader from '@/components/DashboardHeader/DashboardHeader';
+import Noinvited from '@/components/table/no-invited-dashboard/NoInvited';
 
 const MyDashBoard = () => {
   return (
@@ -10,7 +11,7 @@ const MyDashBoard = () => {
       <SideMenu />
       <S.MyDashBoardWrapperStyle>
         <S.ContainerStyle>
-          <DashboardHeader isVisible='false' />
+          <DashboardHeader isVisible='false'>내 대시보드</DashboardHeader>
           {/* <NoInvitedDashboard /> */}
           <InviteDash />
         </S.ContainerStyle>

--- a/query/useGetDashboards.tsx
+++ b/query/useGetDashboards.tsx
@@ -6,7 +6,7 @@ const useGetDashboards = () => {
   return useQuery<ResDashboards>({
     queryFn: async () => {
       try {
-        const res = await api.get(`/dashboards/?navigationMethod=pagination&cursorId=0&size=5&page=2`);
+        const res = await api.get(`/dashboards/?navigationMethod=pagination&cursorId=0&size=1000&page=1`);
         return res.data;
       } catch (e) {}
     },


### PR DESCRIPTION
## 작업 내용
- sideMenu, /mydashboard 상단의 데시보드 버튼들 클릭 시 해당 dashboard로 이동
- 초대받은 대시보드 목록 API연동
    - 초대, 수락 버튼 기능 구현
    - 초대 받은 목록 없을 시에 보이는 컴포넌트 조건 달아줌
- 내가 만든 대시보드에만 왕관
- 초대받은 대시보드 검색 기능 구현
- 세로 크기 고정해서 내부에 스크롤 생기게
    - 안그러면 검색어 입력할때마다 위로 올라감
- /mydashboard에 타입에러 나던 부분 해결

## 스크린샷

### 수정전


### 수정후
<img width="1702" alt="image" src="https://github.com/Dodam0719/taskify-4th-8team/assets/144299767/4d16149c-6cb3-4b56-9f4c-58339cc9671d">
<img width="1018" alt="image" src="https://github.com/Dodam0719/taskify-4th-8team/assets/144299767/aec347e0-25f7-4a03-b19e-a14c0566a372">
<img width="1032" alt="image" src="https://github.com/Dodam0719/taskify-4th-8team/assets/144299767/99f3ed9f-7834-4818-b77d-a14b09c20a2c">
<img width="990" alt="image" src="https://github.com/Dodam0719/taskify-4th-8team/assets/144299767/7d1ea703-1565-4ca2-b0ba-45618da156a1">


## 참고 사항
- 
- 
- 
